### PR TITLE
Compatibility Update for LSPDFR 0.4

### DIFF
--- a/Code 3 Callouts/Code 3 Callouts/Code 3 Callouts.csproj
+++ b/Code 3 Callouts/Code 3 Callouts/Code 3 Callouts.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Code 3 Callouts</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/Code 3 Callouts/Code 3 Callouts/Common.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Common.cs
@@ -17,6 +17,7 @@ using System.Diagnostics;
 using static Stealth.Plugins.Code3Callouts.Util.Audio.AudioPlayerEngine;
 using static Stealth.Plugins.Code3Callouts.Util.Audio.AudioDatabase;
 using System.Windows.Forms;
+using LSPD_First_Response.Engine.Scripting.Entities;
 
 namespace Stealth.Plugins.Code3Callouts
 {
@@ -413,6 +414,24 @@ namespace Stealth.Plugins.Code3Callouts
             } else {
                 return false;
             }
+        }
+
+        internal static Persona BuildPersona(Ped Ped, LSPD_First_Response.Gender Gender, DateTime Birthday, int Citations, string Forename, string Surname, ELicenseState LicenseState, int TimesStopped, bool IsWanted, bool IsAgent, bool IsCop)
+        {
+            Persona Persona = Functions.GetPersonaForPed(Ped);
+            Persona.Gender = Gender;
+            Persona.Birthday = Birthday;
+            Persona.Citations = Citations;
+            Persona.Forename = Forename;
+            Persona.Surname = Surname;
+            Persona.ELicenseState = LicenseState;
+            Persona.TimesStopped = TimesStopped;
+            Persona.Wanted = IsWanted;
+
+            if (IsAgent || IsCop)
+                Functions.SetPedAsCop(Ped);
+
+            return Persona;
         }
 
         internal static float GetHeadingToPoint(Vector3 pOriginPoint, Vector3 pDestinationPoint)

--- a/Code 3 Callouts/Code 3 Callouts/Constants.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Constants.cs
@@ -11,7 +11,7 @@ namespace Stealth.Plugins.Code3Callouts
         internal const int LCPDFRDownloadID = 8082;
 
         internal const string ReqCommonVersion = "2.0.6685.38422";
-        internal const string ReqRPHVersion = "0.52.1061.10387";
+        internal const string ReqRPHVersion = "0.62.1216.14731";
         internal const string ReqLSPDFRVersion = "0.4.39.22580";
         internal const string ReqRNUIVersion = "1.5.1.0";
     }

--- a/Code 3 Callouts/Code 3 Callouts/Constants.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Constants.cs
@@ -10,9 +10,9 @@ namespace Stealth.Plugins.Code3Callouts
     {
         internal const int LCPDFRDownloadID = 8082;
 
-        internal const string ReqCommonVersion = "1.7.6326.22563";
+        internal const string ReqCommonVersion = "2.0.6685.38422";
         internal const string ReqRPHVersion = "0.52.1061.10387";
-        internal const string ReqLSPDFRVersion = "0.3.38.5436";
+        internal const string ReqLSPDFRVersion = "0.4.39.22580";
         internal const string ReqRNUIVersion = "1.5.1.0";
     }
 }

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/Assault.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/Assault.cs
@@ -440,7 +440,7 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 			w.PhysicalCondition = "Subject speaking normally, and making eye contact when he speaks.";
 
             LSPD_First_Response.Engine.Scripting.Entities.Persona pWitness = Functions.GetPersonaForPed(w);
-            LSPD_First_Response.Engine.Scripting.Entities.Persona pNewWitness = new LSPD_First_Response.Engine.Scripting.Entities.Persona(w, pWitness.Gender, pWitness.BirthDay, 0, pWitness.Forename, pWitness.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, false,
+            LSPD_First_Response.Engine.Scripting.Entities.Persona pNewWitness = BuildPersona(w, pWitness.Gender, pWitness.Birthday, 0, pWitness.Forename, pWitness.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, false,
 			false);
 			Functions.SetPersonaForPed(w, pNewWitness);
 

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/BackupDomestic.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/BackupDomestic.cs
@@ -206,10 +206,10 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 				pDataSuspect = LSPD_First_Response.Mod.API.Functions.GetPersonaForPed(pSuspect);
 				int mSuspectWanted = Common.gRandom.Next(3);
 				if (mSuspectWanted == 0) {
-					pDataSuspect = new Persona(pSuspect, Gender.Male, pDataSuspect.BirthDay, 0, pDataSuspect.Forename, pDataSuspect.Surname, ELicenseState.Valid, 5, true, false,
+					pDataSuspect = BuildPersona(pSuspect, Gender.Male, pDataSuspect.Birthday, 0, pDataSuspect.Forename, pDataSuspect.Surname, ELicenseState.Valid, 5, true, false,
 					false);
 				} else {
-					pDataSuspect = new Persona(pSuspect, Gender.Male, pDataSuspect.BirthDay, 0, pDataSuspect.Forename, pDataSuspect.Surname, ELicenseState.Valid, 5, false, false,
+					pDataSuspect = BuildPersona(pSuspect, Gender.Male, pDataSuspect.Birthday, 0, pDataSuspect.Forename, pDataSuspect.Surname, ELicenseState.Valid, 5, false, false,
 					false);
 				}
 				LSPD_First_Response.Mod.API.Functions.SetPersonaForPed(pSuspect, pDataSuspect);
@@ -217,10 +217,10 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 				pDataVictim = LSPD_First_Response.Mod.API.Functions.GetPersonaForPed(pVictim);
 				int mVictimWanted = Common.gRandom.Next(5);
 				if (mVictimWanted == 0) {
-					pDataVictim = new Persona(pVictim, Gender.Female, pDataVictim.BirthDay, 0, pDataVictim.Forename, pDataVictim.Surname, ELicenseState.Valid, 0, true, false,
+					pDataVictim = BuildPersona(pVictim, Gender.Female, pDataVictim.Birthday, 0, pDataVictim.Forename, pDataVictim.Surname, ELicenseState.Valid, 0, true, false,
 					false);
 				} else {
-					pDataVictim = new Persona(pVictim, Gender.Female, pDataVictim.BirthDay, 0, pDataVictim.Forename, pDataVictim.Surname, ELicenseState.Valid, 0, false, false,
+					pDataVictim = BuildPersona(pVictim, Gender.Female, pDataVictim.Birthday, 0, pDataVictim.Forename, pDataVictim.Surname, ELicenseState.Valid, 0, false, false,
 					false);
 				}
 				LSPD_First_Response.Mod.API.Functions.SetPersonaForPed(pVictim, pDataVictim);

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/PersonWithWeapon.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/PersonWithWeapon.cs
@@ -100,7 +100,7 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 
 			if (typeFactor >= 3) {
 				SuspectType = SuspectTypeEnum.Suspect;
-				p = new LSPD_First_Response.Engine.Scripting.Entities.Persona(pSuspect, p.Gender, p.BirthDay, p.Citations, p.Forename, p.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Suspended, p.TimesStopped, true, false,
+				p = BuildPersona(pSuspect, p.Gender, p.Birthday, p.Citations, p.Forename, p.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Suspended, p.TimesStopped, true, false,
 				false);
 				Functions.SetPersonaForPed(pSuspect, p);
 				Logger.LogVerboseDebug("SuspectType = Suspect");
@@ -139,7 +139,7 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 						break;
 				}
 
-				p = new LSPD_First_Response.Engine.Scripting.Entities.Persona(pSuspect, p.Gender, p.BirthDay, 0, p.Forename, p.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, mIsAgent,
+				p = BuildPersona(pSuspect, p.Gender, p.Birthday, 0, p.Forename, p.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, mIsAgent,
 				mIsCop);
 				LSPD_First_Response.Mod.API.Functions.SetPersonaForPed(pSuspect, p);
 				pSuspect.BlockPermanentEvents = false;

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/RoadRage.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/RoadRage.cs
@@ -163,8 +163,8 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 				}
 
 				LSPD_First_Response.Engine.Scripting.Entities.Persona pDataVictim = Functions.GetPersonaForPed(pedVictim);
-				if (pDataVictim.Wanted | pDataVictim.LicenseState != LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid) {
-					pDataVictim = new LSPD_First_Response.Engine.Scripting.Entities.Persona(pedVictim, pDataVictim.Gender, pDataVictim.BirthDay, pDataVictim.Citations, pDataVictim.Forename, pDataVictim.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, pDataVictim.TimesStopped, false, false,
+				if (pDataVictim.Wanted | pDataVictim.ELicenseState != LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid) {
+					pDataVictim = BuildPersona(pedVictim, pDataVictim.Gender, pDataVictim.Birthday, pDataVictim.Citations, pDataVictim.Forename, pDataVictim.Surname, LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, pDataVictim.TimesStopped, false, false,
 					false);
 					Functions.SetPersonaForPed(pedVictim, pDataVictim);
 				}

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/UnknownTrouble.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/Callout Types/UnknownTrouble.cs
@@ -428,10 +428,10 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts.CalloutTypes
 			DetectiveState = EDetectiveState.Created;
 
 			System.DateTime DoB = Common.GetRandomDateOfBirth();
-			string name = LSPD_First_Response.Engine.Scripting.Entities.Persona.GetRandomFullName();
+			string name = LSPD_First_Response.Engine.Scripting.Entities.PersonaHelper.GetRandomFullName();
 			string[] nameParts = name.Split(' ');
 			detName = nameParts[1];
-            LSPD_First_Response.Engine.Scripting.Entities.Persona p = new LSPD_First_Response.Engine.Scripting.Entities.Persona(det, Gender.Male, DoB, 0, nameParts[0], nameParts[1], LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, false,
+            LSPD_First_Response.Engine.Scripting.Entities.Persona p = BuildPersona(det, Gender.Male, DoB, 0, nameParts[0], nameParts[1], LSPD_First_Response.Engine.Scripting.Entities.ELicenseState.Valid, 0, false, false,
 			true);
 			det.Inventory.GiveNewWeapon(new WeaponDescriptor("WEAPON_PISTOL"), 56, false);
 			LSPD_First_Response.Mod.API.Functions.SetPersonaForPed(det, p);

--- a/Code 3 Callouts/Code 3 Callouts/Models/Callouts/CalloutBase.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Models/Callouts/CalloutBase.cs
@@ -114,7 +114,7 @@ namespace Stealth.Plugins.Code3Callouts.Models.Callouts
                     {
                         LSPD_First_Response.Engine.Scripting.Entities.Persona pData = Functions.GetPersonaForPed(Common.ClosestPed);
                         string IDTextFormat = "~b~{0}~n~~y~{1}, ~w~Born: ~y~{2}";
-                        string IDText = string.Format(IDTextFormat, pData.FullName, pData.Gender.ToString(), pData.BirthDay.ToString("M/d/yyyy"));
+                        string IDText = string.Format(IDTextFormat, pData.FullName, pData.Gender.ToString(), pData.Birthday.ToString("M/d/yyyy"));
 
                         Game.DisplayNotification("mpcharselect", "mp_generic_avatar", "STATE ISSUED IDENTIFICATION", pData.FullName.ToUpper(), IDText);
                     }


### PR DESCRIPTION
- Persona no longer supports giving all data during init. For now, we'll just pass it through to BuildPersona which manually adds everything. Params are the same for now. No gameplay changes, more can be done with Persona later (WantedInformation for example was added)
- Updated .NET framework to 4.7.2

This commit (once compiled with the new LSPDFR 0.4 .dll) should make the plugin run with LSPDFR 0.4. I noticed some strange AI behavior in the Burglary In Progress callout in specific which will need to be addressed later. Everything should at least be functional with this commit. Requires new Stealth.Common.dll compiled with .NET 4.7.2 (pull request done)

CROSS UPDATE WITH STEALTH.COMMON